### PR TITLE
Separation of concerns

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -220,4 +220,5 @@ With this guide, you should be able to:
 - ✅ **Use a pre-trained or custom MobileNet model.**
 - ✅ **Build and run the server in production with PM2.**
 
+
 🚀 **Happy Coding!** 🎉

--- a/server/jest.config.ts
+++ b/server/jest.config.ts
@@ -6,7 +6,7 @@ export default {
   preset: 'ts-jest',
   testEnvironment: 'node',
   moduleNameMapper: {
-    '^@/(.*)$': '<rootDir>/src/$1'
+    '^@/(.*)$': '<rootDir>/src/$1' // ✅ Ensures Jest resolves @/ correctly
   },
   moduleDirectories: ['node_modules', 'src'],
   testMatch: [
@@ -15,6 +15,7 @@ export default {
   ],
   testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/build/', '<rootDir>/dist/'],
   transform: {
-    '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.jest.json' }]
-  }
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.jest.json' }] // ✅ Ensures Jest uses tsconfig.jest.json
+  },
+  verbose: true
 };

--- a/server/src/embeddings/EmbeddingsController.test.ts
+++ b/server/src/embeddings/EmbeddingsController.test.ts
@@ -1,24 +1,36 @@
+class TestGraphModel {
+  execute(tensor: any) {
+    return {
+      data: async () => [0.1, 0.2, 0.3],
+    }
+  }
+}
+
+import * as fs from 'fs'
+
 import * as tf from '@tensorflow/tfjs-node'
 import * as mobilenet from '@tensorflow-models/mobilenet'
+import * as dotenv from 'dotenv'
 
-import { LoggerService } from '../services/logger'
-import EmbeddingController from '../embeddings/EmbeddingsController'
+import { LoggerService } from '../services/logger/LoggerService'
+import EmbeddingController, { EmbeddingController as ECClass } from '../embeddings/EmbeddingsController'
 
-// ✅ Properly Mock TensorFlow's loadGraphModel without requireActual
-jest.mock('@tensorflow/tfjs-node', () => ({
-  tensor: jest.fn(() => ({
-    expandDims: jest.fn().mockReturnValue({
-      data: jest.fn().mockResolvedValue([0.1, 0.2, 0.3]),
-    }),
-  })),
-  loadGraphModel: jest.fn().mockResolvedValue({
-    execute: jest.fn().mockReturnValue({
-      data: jest.fn().mockResolvedValue([0.1, 0.2, 0.3]),
-    }),
-  }),
-}))
+dotenv.config()
 
-// ✅ Mock MobileNet
+// --- Mock setup ---
+
+jest.mock('@tensorflow/tfjs-node', () => {
+  return {
+    tensor: jest.fn(() => ({
+      expandDims: jest.fn().mockReturnValue({
+        data: jest.fn().mockResolvedValue([0.1, 0.2, 0.3]),
+      }),
+    })),
+    loadGraphModel: jest.fn().mockResolvedValue(new TestGraphModel()),
+    GraphModel: TestGraphModel,
+  }
+})
+
 jest.mock('@tensorflow-models/mobilenet', () => ({
   load: jest.fn().mockResolvedValue({
     infer: jest.fn().mockReturnValue({
@@ -27,12 +39,10 @@ jest.mock('@tensorflow-models/mobilenet', () => ({
   }),
 }))
 
-// ✅ Mock File System
 jest.mock('fs', () => ({
   existsSync: jest.fn(),
 }))
 
-// ✅ Mock LoggerService to avoid console noise
 jest.mock('../services/logger/LoggerService', () => ({
   LoggerService: {
     info: jest.fn(),
@@ -43,29 +53,28 @@ jest.mock('../services/logger/LoggerService', () => ({
 
 describe('EmbeddingController', () => {
   beforeEach(() => {
-    jest.clearAllMocks()
-
-    // ✅ Reset Singleton Instance
-    const realInstance = Reflect.get(EmbeddingController, 'instance')
-    Reflect.set(EmbeddingController, 'instance', null)
+    // Reset modules so the getter re-reads process.env.
+    jest.resetModules()
+    process.env.USE_CUSTOM_MODEL = 'false'
+    // Clear the singleton instance.
+    Reflect.set(ECClass, 'instance', null)
   })
 
   afterEach(() => {
-    // ✅ Cleanup environment variables to avoid test pollution
     delete process.env.USE_CUSTOM_MODEL
   })
 
   describe('Singleton Pattern', () => {
     it('should return the same instance', () => {
-      const instance1 = EmbeddingController
-      const instance2 = EmbeddingController
+      const instance1 = ECClass.getInstance()
+      const instance2 = ECClass.getInstance()
       expect(instance1).toBe(instance2)
     })
   })
 
   describe('loadModel()', () => {
     it('should load the default MobileNet model', async () => {
-      await EmbeddingController.loadModel()
+      await ECClass.getInstance().loadModel()
       expect(mobilenet.load).toHaveBeenCalledTimes(1)
       expect(LoggerService.info).toHaveBeenCalledWith('✅ Default MobileNetV2 Model Loaded Successfully!')
     })
@@ -73,17 +82,14 @@ describe('EmbeddingController', () => {
 
   describe('getModel()', () => {
     it('should return the loaded model', async () => {
-      await EmbeddingController.loadModel()
-      const model = EmbeddingController.getModel()
-
+      await ECClass.getInstance().loadModel()
+      const model = ECClass.getInstance().getModel()
       expect(model).toBeDefined()
     })
 
     it('should throw an error if model is not loaded', () => {
-      // ✅ Ensure model is unset
-      Reflect.set(EmbeddingController, 'model', null)
-
-      expect(() => EmbeddingController.getModel()).toThrowError(
+      Reflect.set(ECClass.getInstance(), 'model', null)
+      expect(() => ECClass.getInstance().getModel()).toThrowError(
         '❌ Model not loaded yet! Ensure `loadModel()` is called at startup.',
       )
     })
@@ -91,37 +97,31 @@ describe('EmbeddingController', () => {
 
   describe('getFeatureEmbeddings()', () => {
     it('should generate feature embeddings using default MobileNet', async () => {
-      // ✅ Declare mockData in the correct scope
       const mockData = new Float32Array([0.1, 0.2, 0.3])
-      const dummyTensor = tf.tensor(mockData) // ✅ Corrected Syntax
-
-      await EmbeddingController.loadModel()
-      const embeddings = await EmbeddingController.getFeatureEmbeddings(dummyTensor)
-
+      const dummyTensor = tf.tensor(mockData)
+      await ECClass.getInstance().loadModel()
+      const embeddings = await ECClass.getInstance().getFeatureEmbeddings(dummyTensor)
       expect(embeddings).toBeDefined()
       expect(embeddings.length).toBeGreaterThan(0)
     })
 
     it('should generate feature embeddings using custom model', async () => {
       process.env.USE_CUSTOM_MODEL = 'true'
-
-      // ✅ Declare mockData here as well
+      ;(fs.existsSync as jest.Mock).mockReturnValue(true)
+      Reflect.set(ECClass, 'instance', null)
+      const instance = ECClass.getInstance()
       const mockData = new Float32Array([0.1, 0.2, 0.3])
-      const dummyTensor = tf.tensor(mockData) // ✅ Corrected Syntax
-
-      await EmbeddingController.loadModel()
-      const embeddings = await EmbeddingController.getFeatureEmbeddings(dummyTensor)
-
+      const dummyTensor = tf.tensor(mockData)
+      await instance.loadModel()
+      const embeddings = await instance.getFeatureEmbeddings(dummyTensor)
       expect(embeddings).toBeDefined()
       expect(embeddings.length).toBeGreaterThan(0)
     })
 
     it('should throw an error if model is not loaded', async () => {
-      // ✅ Ensure model is unset
-      Reflect.set(EmbeddingController, 'model', null)
+      Reflect.set(ECClass.getInstance(), 'model', null)
       const dummyTensor = tf.tensor([0.1, 0.2, 0.3])
-
-      await expect(EmbeddingController.getFeatureEmbeddings(dummyTensor)).rejects.toThrowError(
+      await expect(ECClass.getInstance().getFeatureEmbeddings(dummyTensor)).rejects.toThrowError(
         '❌ Model not loaded yet!',
       )
     })

--- a/server/src/handlers/handlers.test.ts
+++ b/server/src/handlers/handlers.test.ts
@@ -1,4 +1,3 @@
-// Mock the entire modules at the top
 jest.mock('../utils/UtilsController', () => ({
   __esModule: true,
   default: {
@@ -69,37 +68,19 @@ describe('Handlers', () => {
       const mockEmbedding = Array(768).fill(0.1)
       const mockUniqueId = 'unique-id'
 
-      // ✅ Corrected Here
-      // Explicitly set the expected ID
       const expectedId: string = `${req.body.label}-${mockUniqueId}`
 
-      // ✅ Separate Mock Implementations
-      // Mocking Image Preprocessing
       ;(UtilsController.preprocessImage as jest.Mock).mockReturnValue(mockTensor)
-
-      // Mocking Feature Embedding Extraction
       ;(EmbeddingController.getFeatureEmbeddings as jest.Mock).mockResolvedValue(mockEmbedding)
-
-      // Mocking Unique ID Generation
       ;(UtilsController.generateUniqueId as jest.Mock).mockReturnValue(mockUniqueId)
 
-      // Ensure saveEmbedding is properly mocked and tracked
       const saveEmbeddingMock = pineconeController.saveEmbedding as jest.Mock
       saveEmbeddingMock.mockResolvedValue(true)
 
-      // Add Debugging Logs
-      console.log('Calling handleImage...')
-      console.log('Expected ID:', expectedId)
-
       await handleImage(req as Request, res as Response)
 
-      // Assert Calls and Parameters
       expect(UtilsController.preprocessImage).toHaveBeenCalledWith(expect.any(Buffer))
       expect(EmbeddingController.getFeatureEmbeddings).toHaveBeenCalledWith(mockTensor)
-
-      // Add Debugging Logs
-      console.log('saveEmbeddingMock.mock.calls:', saveEmbeddingMock.mock.calls)
-
       expect(saveEmbeddingMock).toHaveBeenCalledWith([
         {
           id: expectedId,

--- a/server/src/handlers/handlers.ts
+++ b/server/src/handlers/handlers.ts
@@ -36,7 +36,6 @@ export const handleImage = async (req: any, res: any) => {
     let embedding = await EmbeddingController.getFeatureEmbeddings(tensor)
     LoggerService.info('✅ Extracted Feature Embedding Size:', JSON.stringify(embedding.length))
 
-    // 🚨 Ensure embeddings are 768 dimensions (truncate or pad if needed)
     if (embedding.length > pineconeIndexDimensions) {
       embedding = embedding.slice(0, pineconeIndexDimensions)
     } else if (embedding.length < pineconeIndexDimensions) {

--- a/server/src/index.test.ts
+++ b/server/src/index.test.ts
@@ -5,7 +5,6 @@ import pineconeController from './pinecone/PineconeController'
 
 import { app, loadClassLabels } from './index'
 
-// Mock dependencies
 jest.mock('./embeddings/EmbeddingsController', () => ({
   getModel: jest.fn(),
   useCustomModel: true,
@@ -20,8 +19,6 @@ jest.mock('./utils/UtilsController', () => ({
   preprocessImage: jest.fn().mockReturnValue('mockedTensor'),
   applySoftmax: jest.fn().mockReturnValue([0.1, 0.2, 0.3]),
 }))
-
-// Mock LoggerService to suppress console output during tests
 jest.mock('@/services/logger/LoggerService', () => ({
   LoggerService: {
     info: jest.fn(),
@@ -30,11 +27,10 @@ jest.mock('@/services/logger/LoggerService', () => ({
   },
 }))
 
-// Force testing port and environment
 process.env.PORT = '3001'
 process.env.NODE_ENV = 'test'
 
-let testServer: any // Store the server instance
+let testServer: any
 
 beforeAll(async () => {
   await loadClassLabels()
@@ -44,7 +40,7 @@ beforeAll(async () => {
 })
 
 afterAll((done) => {
-  if (testServer) testServer.close(done) // Close the server properly
+  if (testServer) testServer.close(done)
 })
 
 describe('/train Endpoint', () => {
@@ -54,7 +50,6 @@ describe('/train Endpoint', () => {
 
   it('should return 400 if data, label, or user is missing', async () => {
     const response = await request(app).post('/train').send({})
-
     expect(response.status).toBe(400)
     expect(response.body).toEqual({ error: 'Missing data, label, or user!' })
   })
@@ -95,7 +90,7 @@ describe('/detect Endpoint', () => {
   it('should return 500 if predictions are invalid', async () => {
     ;(EmbeddingController.getModel as jest.Mock).mockReturnValue({
       execute: jest.fn().mockReturnValue({
-        array: jest.fn().mockResolvedValue([]), // Return an empty array
+        array: jest.fn().mockResolvedValue([]),
       }),
     })
 
@@ -151,7 +146,6 @@ describe('/detect Endpoint', () => {
   })
 
   it('should return 500 if an unexpected error occurs', async () => {
-    // Mock getModel to return a valid model to bypass the middleware
     ;(EmbeddingController.getModel as jest.Mock).mockReturnValue({
       execute: jest.fn().mockImplementationOnce(() => {
         throw new Error('Unexpected error!')

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,18 +1,13 @@
 import express from 'express'
 import cors from 'cors'
 import { fetch } from 'undici'
-import * as tf from '@tensorflow/tfjs-node'
 import dotenv from 'dotenv'
 
 import EmbeddingController from '@/embeddings/EmbeddingsController'
-import pineconeController from '@/pinecone/PineconeController'
-import utilsController from '@/utils/UtilsController'
 import { LoggerService } from '@/services/logger/LoggerService'
+import routes from '@/routes'
 
 dotenv.config()
-
-const pineconeDimensions = process.env.PINECONE_DIMENSIONS || 768
-const pineconeIndexDimensions = Number(pineconeDimensions)
 
 const app = express()
 app.use(cors())
@@ -24,11 +19,9 @@ const PORT = process.env.PORT || 3000
 
 /**
  * Load ImageNet class labels from a remote URL
- * @returns {Promise<void>}
  */
 export async function loadClassLabels() {
   LoggerService.debug('🔍 Loading ImageNet class labels...')
-
   try {
     const response = await fetch(CLASS_INDEX_URL)
     classLabels = (await response.json()) as Record<string, any>
@@ -40,14 +33,9 @@ export async function loadClassLabels() {
 
 /**
  * Middleware to ensure the MobileNet model is loaded before handling requests
- * @param req
- * @param res
- * @param next
- * @returns {void}
  */
 export function ensureModelLoaded(req: express.Request, res: express.Response, next: express.NextFunction) {
   LoggerService.debug('🔍 Checking if model is loaded...')
-
   try {
     EmbeddingController.getModel()
     next()
@@ -56,108 +44,15 @@ export function ensureModelLoaded(req: express.Request, res: express.Response, n
   }
 }
 
-/**
- * Detect endpoint to query embeddings from Pinecone.
- * @returns {Promise<void>}
- */
-app.post('/detect', ensureModelLoaded, async (req, res) => {
-  LoggerService.debug('/detect API endpoint')
-
-  try {
-    LoggerService.info('🚀 Detection started...')
-
-    const { data, user } = req.body
-    if (!data || !user) return res.status(400).json({ error: 'Missing image or user!' })
-
-    LoggerService.info('🛠️ Processing image for detection...')
-    LoggerService.debug(`🔍 Image size received: ${data.length} characters`)
-
-    const input = utilsController.preprocessImage(Buffer.from(data, 'base64'))
-    const model = EmbeddingController.getModel()
-
-    let predictions: tf.Tensor
-    if (EmbeddingController.useCustomModel && 'execute' in model) {
-      predictions = model.execute(input) as tf.Tensor
-    } else if ('infer' in model) {
-      predictions = model.infer(input, true) as tf.Tensor
-    } else {
-      throw new Error('❌ Model type is unknown!')
-    }
-
-    const rawScores = (await predictions.array()) as number[][]
-
-    if (!Array.isArray(rawScores) || rawScores.length === 0) {
-      return res.status(500).json({ error: 'Invalid predictions from model' })
-    }
-
-    let embedding = utilsController.applySoftmax(rawScores[0])
-
-    if (embedding.length > pineconeIndexDimensions) embedding = embedding.slice(0, pineconeIndexDimensions)
-    if (embedding.length < pineconeIndexDimensions)
-      embedding = embedding.concat(new Array(pineconeIndexDimensions - embedding.length).fill(0))
-
-    LoggerService.info('🔄 Querying Pinecone with the generated embedding...')
-
-    const pineconeResults = await pineconeController.queryEmbedding({
-      embedding,
-      namespace: user,
-      topK: 3,
-    })
-
-    if (!pineconeResults.length) {
-      return res.json({ detectedLabel: 'Unknown Object', confidence: '0%' })
-    }
-
-    const formattedResults = pineconeResults.map((match: any) => ({
-      label: match.metadata.label,
-      confidence: `${Math.min(match.score * 100, 100).toFixed(2)}%`,
-    }))
-
-    res.json({ matches: formattedResults })
-  } catch (error: any) {
-    LoggerService.error('❌ Detection error:', error)
-    res.status(500).json({ error: 'Detection failed!', details: error.message })
-  }
-})
-
-/**
- * Train endpoint to save new embeddings to Pinecone.
- * @returns {Promise<void>}
- */
-app.post('/train', ensureModelLoaded, async (req, res) => {
-  LoggerService.debug('/train API endpoint')
-
-  try {
-    const { data, label, user } = req.body
-    if (!data || !label || !user) {
-      return res.status(400).json({ error: 'Missing data, label, or user!' })
-    }
-
-    const imageBuffer = Buffer.from(data, 'base64')
-    const tensor = utilsController.preprocessImage(imageBuffer)
-    LoggerService.info('✅ Image processed for training.')
-
-    let embedding = await EmbeddingController.getFeatureEmbeddings(tensor)
-
-    const upsertPayload = [{ id: `${user}-${label}-${Date.now()}`, values: embedding, metadata: { label, user } }]
-    await pineconeController.saveEmbedding(upsertPayload)
-
-    res.json({ message: 'Training completed successfully!' })
-  } catch (error: any) {
-    LoggerService.error('❌ Training error:', error.message)
-    res.status(500).json({ error: 'Training failed!', details: error.message })
-  }
-})
+app.use('/', routes)
 
 let server: ReturnType<typeof app.listen> | undefined
 
 /**
  * Start the server without top-level await
- * @returns {void}
  */
 export function startServer(): void {
   LoggerService.debug('🚀 Starting server...')
-
   Promise.all([EmbeddingController.loadModel(), loadClassLabels()])
     .then(() => {
       server = app.listen(PORT, () => LoggerService.info(`🚀 Server running on port ${PORT}`))
@@ -168,10 +63,11 @@ export function startServer(): void {
     })
 }
 
-// ✅ Conditionally start server if NOT in test environment
 if (process.env.NODE_ENV !== 'test') {
   startServer()
 }
 
-// Exporting for testing
+/**
+ * Export the app and server for testing
+ */
 export { app, server }

--- a/server/src/pinecone/PineconeController.test.ts
+++ b/server/src/pinecone/PineconeController.test.ts
@@ -14,7 +14,6 @@ jest.mock('../services/logger/LoggerService', () => ({
   },
 }))
 
-// Move mock variable declarations INSIDE jest.mock()
 jest.mock('@pinecone-database/pinecone', () => {
   // Declare and initialize mocks here
   const mockUpsert = jest.fn()
@@ -68,25 +67,20 @@ describe('PineconeController', () => {
     })
 
     it('should throw error if index is not found', async () => {
-      // Mock listIndexes to always resolve with an empty array
       const mockListIndexes = jest.fn().mockResolvedValue({
         indexes: [], // ❌ Empty array ensures indexName won't be found
       })
 
-      // Override the original method with the mock
       pineconeController['pinecone'].listIndexes = mockListIndexes
 
-      // Force the condition by explicitly setting the indexName to 'test-index'
       pineconeController['indexName'] = 'test-index'
 
-      // Call the method and catch the error manually
       try {
         await pineconeController.initializeIndex()
       } catch (error: any) {
         expect(error.message).toBe(`Pinecone index 'test-index' not found!`)
       }
 
-      // Ensure that the error was actually thrown
       expect(mockListIndexes).toHaveBeenCalled()
     })
   })

--- a/server/src/pinecone/PineconeController.ts
+++ b/server/src/pinecone/PineconeController.ts
@@ -164,7 +164,6 @@ export class PineconeController {
         throw new Error('❌ ERROR: Pinecone Index is undefined.')
       }
 
-      // ✅ Correct Pinecone deletion method (delete all vectors in namespace)
       await this.index.deleteMany({ filter: { user: namespace } })
 
       LoggerService.info('✅ Namespace deleted:', namespace)

--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -1,17 +1,102 @@
 import express from 'express'
+import * as tf from '@tensorflow/tfjs-node'
 
 import { handleImage, handleDeleteUser } from '@/handlers/handlers'
+import { ensureModelLoaded } from '@/index'
+import EmbeddingController from '@/embeddings/EmbeddingsController'
+import pineconeController from '@/pinecone/PineconeController'
+import utilsController from '@/utils/UtilsController'
+import { LoggerService } from '@/services/logger/LoggerService'
 
 const router = express.Router()
 
 router.get('/health', (_, res) => res.send('ok'))
 
+// /train Endpoint
+router.post('/train', ensureModelLoaded, async (req, res) => {
+  LoggerService.debug('/train API endpoint')
+  try {
+    const { data, label, user } = req.body
+    if (!data || !label || !user) {
+      return res.status(400).json({ error: 'Missing data, label, or user!' })
+    }
+    const imageBuffer = Buffer.from(data, 'base64')
+    const tensor = utilsController.preprocessImage(imageBuffer)
+    LoggerService.info('✅ Image processed for training.')
+
+    let embedding = await EmbeddingController.getFeatureEmbeddings(tensor)
+    const upsertPayload = [
+      {
+        id: `${user}-${label}-${Date.now()}`,
+        values: embedding,
+        metadata: { label, user },
+      },
+    ]
+    await pineconeController.saveEmbedding(upsertPayload)
+    res.json({ message: 'Training completed successfully!' })
+  } catch (error: any) {
+    LoggerService.error('❌ Training error:', error.message)
+    res.status(500).json({ error: 'Training failed!', details: error.message })
+  }
+})
+
+// /detect Endpoint
+router.post('/detect', ensureModelLoaded, async (req, res) => {
+  LoggerService.debug('/detect API endpoint')
+  try {
+    LoggerService.info('🚀 Detection started...')
+    const { data, user } = req.body
+    if (!data || !user) {
+      return res.status(400).json({ error: 'Missing image or user!' })
+    }
+    LoggerService.info('🛠️ Processing image for detection...')
+    LoggerService.debug(`🔍 Image size received: ${data.length} characters`)
+    const input = utilsController.preprocessImage(Buffer.from(data, 'base64'))
+    const model = EmbeddingController.getModel()
+
+    let predictions: tf.Tensor
+    if (EmbeddingController.useCustomModel && 'execute' in model) {
+      predictions = model.execute(input) as tf.Tensor
+    } else if ('infer' in model) {
+      predictions = model.infer(input, true) as tf.Tensor
+    } else {
+      throw new Error('❌ Model type is unknown!')
+    }
+
+    const rawScores = (await predictions.array()) as number[][]
+    if (!Array.isArray(rawScores) || rawScores.length === 0) {
+      return res.status(500).json({ error: 'Invalid predictions from model' })
+    }
+    let embedding = utilsController.applySoftmax(rawScores[0])
+    const pineconeDimensions = process.env.PINECONE_DIMENSIONS || 768
+    const pineconeIndexDimensions = Number(pineconeDimensions)
+    if (embedding.length > pineconeIndexDimensions) embedding = embedding.slice(0, pineconeIndexDimensions)
+    if (embedding.length < pineconeIndexDimensions)
+      embedding = embedding.concat(new Array(pineconeIndexDimensions - embedding.length).fill(0))
+
+    LoggerService.info('🔄 Querying Pinecone with the generated embedding...')
+    const pineconeResults = await pineconeController.queryEmbedding({
+      embedding,
+      namespace: user,
+      topK: 3,
+    })
+
+    if (!pineconeResults.length) {
+      return res.json({ detectedLabel: 'Unknown Object', confidence: '0%' })
+    }
+
+    const formattedResults = pineconeResults.map((match: any) => ({
+      label: match.metadata.label,
+      confidence: `${Math.min(match.score * 100, 100).toFixed(2)}%`,
+    }))
+    res.json({ matches: formattedResults })
+  } catch (error: any) {
+    LoggerService.error('❌ Detection error:', error)
+    res.status(500).json({ error: 'Detection failed!', details: error.message })
+  }
+})
+
 router.post('/api/image', handleImage)
-
-router.post('/train', handleImage)
-
-router.post('/detect', handleImage)
-
 router.delete('/user', handleDeleteUser)
 
 export default router

--- a/server/src/services/logger/LoggerService.test.ts
+++ b/server/src/services/logger/LoggerService.test.ts
@@ -1,4 +1,3 @@
-// Mock stringify before importing LoggerService
 jest.mock('safe-stable-stringify', () => ({
   __esModule: true, // Required for proper mocking of ES Modules
   default: jest.fn((data) => JSON.stringify(data)),
@@ -6,7 +5,6 @@ jest.mock('safe-stable-stringify', () => ({
 
 import { LoggerService } from './LoggerService'
 
-// Use require to properly import default export for mocking
 const stringifyMock = require('safe-stable-stringify').default
 
 describe('LoggerService', () => {
@@ -16,7 +14,6 @@ describe('LoggerService', () => {
     jest.spyOn(console, 'log').mockImplementation(() => {})
     jest.spyOn(console, 'error').mockImplementation(() => {})
 
-    // Reset the areDebugLogsOn static property before each test
     LoggerService.areDebugLogsOn = process.env.VERBOSE === 'true'
   })
 

--- a/server/src/services/logger/LoggerService.ts
+++ b/server/src/services/logger/LoggerService.ts
@@ -133,7 +133,6 @@ export class LoggerService {
    * @private
    */
   private static async _logData(data: string | object | [] | undefined | null = {}): Promise<boolean> {
-    // Check for empty object, empty array, undefined, or null
     if (
       data === undefined ||
       data === null ||

--- a/server/tsconfig.jest.json
+++ b/server/tsconfig.jest.json
@@ -1,13 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": ".",
-    "baseUrl": ".",
-    "esModuleInterop": true,
+    "baseUrl": "./",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     },
+    "esModuleInterop": true,
     "resolveJsonModule": true
   },
-  "include": ["jest.config.ts", "src"]
+  "include": ["src"]
 }


### PR DESCRIPTION
## Description
refactor(routes): extract endpoint logic into routes.ts

- Move /train, /detect, and related endpoint implementations from index.ts to routes.ts
- Update index.ts to mount routes, keeping server initialization separate
- Adjust tests and module resolution to reflect the new structure